### PR TITLE
fix link to CCSDS 505

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 <p>
   In 2010, CCSDS published an
-  <a href='https://public.ccsds.org/Pubs/505x0b1.pdf'>
+  <a href='https://public.ccsds.org/Pubs/505x0b2.pdf'>
     XML SPECIFICATION FOR NAVIGATION DATA MESSAGES
   </a>
   to aid developers in creating web services based on CCSDS standards, using


### PR DESCRIPTION
fix link to CCSDS 505.0-B-2 XML SPECIFICATION FOR NAVIGATION DATA MESSAGES
new version is available at: https://public.ccsds.org/Pubs/505x0b2.pdf
historical version is now at: https://public.ccsds.org/Pubs/505x0b1s.pdf