### PR TITLE
Home - Fix link for XML specification

### DIFF
--- a/src/lib/Pages/Home.svelte
+++ b/src/lib/Pages/Home.svelte
@@ -26,7 +26,7 @@
             </p>
             <p>
                 In 2010, CCSDS published an
-                <a href="https://public.ccsds.org/Pubs/505x0b1.pdf">
+                <a href="https://public.ccsds.org/Pubs/505x0b2.pdf">
                     XML SPECIFICATION FOR NAVIGATION DATA MESSAGES
                 </a>
                 to aid developers in creating web services based on CCSDS standards,


### PR DESCRIPTION
This link now points to the same address as the one found in the README.
One thing to note is that this is not the original document, the original is located at:
https://public.ccsds.org/Pubs/505x0b1s.pdf

while the latest revision is located here: https://public.ccsds.org/Pubs/505x0b2.pdf