### PR TITLE
add support for publishing to crates.io

### DIFF
--- a/lib/rs/.gitignore
+++ b/lib/rs/.gitignore
@@ -1,0 +1,5 @@
+target
+src
+Cargo.toml
+Cargo.lock
+publish_cargo.env

--- a/lib/rs/publish_cargo.sh
+++ b/lib/rs/publish_cargo.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Load environment variables
+source publish_cargo.env
+
+# Ensure the cargo registry token is provided
+if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+    echo "Error: The CARGO_REGISTRY_TOKEN environment variable is not set."
+    exit 1
+fi
+
+# Log in to crates.io
+echo "Logging in to crates.io..."
+cargo login $CARGO_REGISTRY_TOKEN
+
+# Dry run to verify the package
+echo "Performing dry run..."
+cargo publish --dry-run
+
+# List package contents
+echo "Listing package contents..."
+cargo package --list
+
+# Publish the crate
+echo "Publishing the crate..."
+cargo publish
+
+echo "Crate published successfully!"

--- a/lib/rs/publish_cargo_example.env
+++ b/lib/rs/publish_cargo_example.env
@@ -1,0 +1,7 @@
+# The token for crates.io may be specified with the CARGO_REGISTRY_TOKEN environment variable. 
+# Tokens for other registries may be specified with environment variables of the form 
+# CARGO_REGISTRIES_<name>_TOKEN where <name> is the name of the registry in all capital letters.
+# https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials
+
+# Generate Cargo API Token here if needed: https://crates.io/settings/tokens
+CARGO_REGISTRY_TOKEN="" 

--- a/scripts/generateCargoPackage.js
+++ b/scripts/generateCargoPackage.js
@@ -1,0 +1,120 @@
+import fs from "fs";
+import path from "path";
+
+const directoryPath = path.join("lib", "rs");
+const srcDir = path.join(directoryPath, "src");
+const libFilePath = path.join(srcDir, "lib.rs");
+const mainGeneratedFilePath = path.join(srcDir, "main_generated.rs");
+
+// Function to reset the directory structure
+function resetDirectoryStructure() {
+  if (fs.existsSync(srcDir)) {
+    // Move lib.rs and main_generated.rs back to their original location
+    if (fs.existsSync(libFilePath)) {
+      fs.renameSync(libFilePath, path.join(directoryPath, "lib.rs"));
+    }
+    if (fs.existsSync(mainGeneratedFilePath)) {
+      fs.renameSync(
+        mainGeneratedFilePath,
+        path.join(directoryPath, "main_generated.rs")
+      );
+    }
+
+    // Move all module directories back to their original location
+    fs.readdirSync(srcDir, { withFileTypes: true })
+      .filter((dirent) => dirent.isDirectory())
+      .forEach((dirent) => {
+        const moduleDirPath = path.join(srcDir, dirent.name);
+        const originalDirPath = path.join(directoryPath, dirent.name);
+        fs.renameSync(moduleDirPath, originalDirPath);
+      });
+
+    // Remove the src directory if empty
+    if (fs.readdirSync(srcDir).length === 0) {
+      fs.rmdirSync(srcDir);
+    }
+  }
+}
+
+// Function to generate Cargo.toml
+function generateCargoToml() {
+  const cargoTomlContent = `
+[package]
+name = "digitalarsenal-standards"
+version = "0.1.0"
+edition = "2021"
+description = "Space data standards framework based on CCSDS standards and Google FlatBuffers."
+license = "Apache-2.0"
+authors = ["sds@digitalarsenal.io", "shanebenlolo@gmail.com"]
+repository = "https://github.com/DigitalArsenal/spacedatastandards.org"
+homepage = "https://spacedatastandards.org"
+exclude = [
+    "publish_cargo.sh",
+    "publish_cargo_env_example.env",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+flatbuffers = "24.3.25"
+  `;
+  fs.writeFileSync(
+    path.join(directoryPath, "Cargo.toml"),
+    cargoTomlContent.trim()
+  );
+}
+
+// Reset the directory structure before running the main logic
+resetDirectoryStructure();
+
+// Generate lib.rs
+let lib = "pub mod main_generated;\n\n";
+fs.readdirSync(directoryPath, { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .forEach((dirent) => {
+    const folderName = dirent.name;
+    if (folderName === "target") return;
+
+    lib += `pub mod ${folderName} {\n`;
+    lib += "    pub mod main_generated;\n";
+    lib += "}\n";
+  });
+fs.writeFileSync(path.join(directoryPath, "lib.rs"), lib);
+
+// Generate main_generated.rs
+let mainGenerated = "";
+fs.readdirSync(directoryPath, { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .forEach((dirent) => {
+    const folderName = dirent.name;
+    if (folderName === "target") return;
+
+    mainGenerated += `pub use crate::${folderName}::main_generated::*;\n`;
+  });
+fs.writeFileSync(path.join(directoryPath, "main_generated.rs"), mainGenerated);
+
+// Create src folder if it doesn't exist
+if (!fs.existsSync(srcDir)) {
+  fs.mkdirSync(srcDir);
+}
+
+// Move lib.rs and main_generated.rs to src
+fs.renameSync(path.join(directoryPath, "lib.rs"), libFilePath);
+fs.renameSync(
+  path.join(directoryPath, "main_generated.rs"),
+  mainGeneratedFilePath
+);
+
+// Move all module directories to src
+fs.readdirSync(directoryPath, { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .forEach((dirent) => {
+    if (dirent.name === "src") {
+      return;
+    }
+    const moduleDirPath = path.join(directoryPath, dirent.name);
+    const newModuleDirPath = path.join(srcDir, dirent.name);
+    fs.renameSync(moduleDirPath, newModuleDirPath);
+  });
+
+// Generate Cargo.toml
+generateCargoToml();


### PR DESCRIPTION
This MR adds support for publishing the rust code generated by Google's FlatBuffers compiler to crates.io. Hopefully I did this right, please review carefully. I did a test run on my local crates.io account here: https://crates.io/crates/publish_cargo_test 
_all credits in the cargo.toml point back to this repo, I just didn't want to push to digitalarsenal-standards without permission_

I was able to create a new project, install the lib, and succesfully run the following program:

```
use publish_cargo_test::BOV::main_generated::*;

fn main() {
    println!("Hello, world!");
    let mut test = BOVT::default();
    println!("{:?}", test);
}

```

The README contains instructions on how to publish the crate, please let me know if you have any questions.

My only concern was that I manually moved the generated files from `/lib/rs/` --> `/lib/rs/src`, please let me know if you think this will be an issue. We can generate the `lib.rs` and `main_generated.rs` and move the generated code into the src folder programmatically as part of the publishing script if needed, but I am hoping we can instead just point the output of the rust code into the `lib/rs/src` directory as a simpler solution.