### PR TITLE
feat: add CTC (Catalog Collection) and OMC (OMM Collection) schemas

### DIFF
--- a/schema/CTC/main.fbs
+++ b/schema/CTC/main.fbs
@@ -1,0 +1,71 @@
+// Hash: 3f494401ae3d89575156c675433dbfb4554143909fabd7bfe3fd5557028093be
+// Version: 0.1.0
+// -----------------------------------END_HEADER
+include "../CAT/main.fbs";
+
+/// Source system that produced this catalog collection.
+enum catalogSource : byte {
+  /// 0 - Unknown or unspecified source
+  UNKNOWN,
+  /// 1 - US Space Command (18 SDS / Space-Track)
+  USSPACECOM,
+  /// 2 - CelesTrak
+  CELESTRAK,
+  /// 3 - European Space Agency (ESA DISCOS)
+  ESA,
+  /// 4 - Beijing Kaiyun Parallel Space Technology (SpaceMapper)
+  SPACEMAPPER,
+  /// 5 - Russian Space Agency (Roscosmos)
+  ROSCOSMOS,
+  /// 6 - Japan Aerospace Exploration Agency
+  JAXA,
+  /// 7 - Indian Space Research Organisation (ISRO)
+  ISRO,
+  /// 8 - Unified Data Library (UDL)
+  UDL,
+  /// 9 - USSF Unified Data Library
+  USSF_UDL,
+  /// 10 - LeoLabs
+  LEOLABS,
+  /// 11 - ExoAnalytic Solutions
+  EXOANALYTIC,
+  /// 12 - Numerica Corporation
+  NUMERICA,
+  /// 13 - Private/custom source
+  PRIVATE
+}
+
+/// Catalog Collection Message
+///
+/// A paginated collection of CAT (Catalog Entity) records from a
+/// space object catalog source. Supports pagination metadata for
+/// incremental catalog retrieval from sources like Space-Track,
+/// CelesTrak, SpaceMapper, ESA DISCOS, or the Unified Data Library.
+table CTC {
+  /// Records in this page/batch
+  RECORDS: [CAT];
+
+  /// Total number of records in the full catalog query result
+  TOTAL: uint32;
+
+  /// Current page index (1-based)
+  PAGE_INDEX: uint32;
+
+  /// Records per page
+  PAGE_SIZE: uint32;
+
+  /// Source system that produced this catalog data
+  SOURCE: catalogSource = UNKNOWN;
+
+  /// ISO 8601 timestamp when this collection was fetched/generated
+  CREATED: string;
+
+  /// Query filter applied (e.g., "countryCode=CN", "objectType=PAYLOAD")
+  QUERY_FILTER: string;
+
+  /// Comment or notes about this collection
+  COMMENT: string;
+}
+
+root_type CTC;
+file_identifier "$CTC";

--- a/schema/OMC/main.fbs
+++ b/schema/OMC/main.fbs
@@ -1,0 +1,46 @@
+// Hash: 09d0784a183a41b5b58bfc695966e162c31d6c7da8632d3a11e960b97bbe53d9
+// Version: 0.1.0
+// -----------------------------------END_HEADER
+include "../OMM/main.fbs";
+include "../CTC/main.fbs";
+
+/// Orbit Mean-Elements Collection Message
+///
+/// A paginated collection of OMM (Orbit Mean-Elements Message) records.
+/// Supports bulk TLE/orbital element retrieval from sources like
+/// Space-Track GP data API, CelesTrak bulk downloads, SpaceMapper
+/// catalog scraping, or any system that produces batched OMM data.
+table OMC {
+  /// OMM records in this page/batch
+  RECORDS: [OMM];
+
+  /// Total number of OMM records in the full query result
+  TOTAL: uint32;
+
+  /// Current page index (1-based)
+  PAGE_INDEX: uint32;
+
+  /// Records per page
+  PAGE_SIZE: uint32;
+
+  /// Source system (reuses catalogSource from CTC)
+  SOURCE: catalogSource = UNKNOWN;
+
+  /// ISO 8601 timestamp when this collection was fetched/generated
+  CREATED: string;
+
+  /// Epoch range start (ISO 8601) — earliest OMM epoch in batch
+  EPOCH_START: string;
+
+  /// Epoch range end (ISO 8601) — latest OMM epoch in batch
+  EPOCH_END: string;
+
+  /// Query filter applied (e.g., "NORAD_CAT_ID=25544")
+  QUERY_FILTER: string;
+
+  /// Comment or notes about this collection
+  COMMENT: string;
+}
+
+root_type OMC;
+file_identifier "$OMC";


### PR DESCRIPTION
## Summary

Adds two new collection/batch wrapper schemas for paginated catalog and orbital element retrieval.

### CTC — Catalog Collection Message (`$CTC`)

A paginated collection of `CAT` (Catalog Entity) records for representing batch responses from any space object catalog source.

**Fields:**
| Field | Type | Description |
|-------|------|-------------|
| RECORDS | [CAT] | Catalog records in this page |
| TOTAL | uint32 | Total records in full query result |
| PAGE_INDEX | uint32 | Current page (1-based) |
| PAGE_SIZE | uint32 | Records per page |
| SOURCE | catalogSource | Source system enum |
| CREATED | string | ISO 8601 fetch timestamp |
| QUERY_FILTER | string | Applied filter |
| COMMENT | string | Notes |

**`catalogSource` enum:** UNKNOWN, USSPACECOM, CELESTRAK, ESA, SPACEMAPPER, ROSCOSMOS, JAXA, ISRO, UDL, USSF_UDL, LEOLABS, EXOANALYTIC, NUMERICA, PRIVATE

### OMC — Orbit Mean-Elements Collection Message (`$OMC`)

A paginated collection of `OMM` records for bulk TLE/orbital element retrieval.

**Additional fields:** `EPOCH_START`, `EPOCH_END` (ISO 8601 temporal range for the batch)

### Motivation

- `LDM` already uses `[CAT]` but is launch-specific — no general-purpose catalog collection exists
- No existing schema wraps `[OMM]` for bulk TLE responses
- Every catalog source (Space-Track, CelesTrak, SpaceMapper, ESA DISCOS, UDL) returns paginated results
- The `spacemapper` SDN plugin needs `$CTC` for its catalog page output
- Space-Track GP data API returns bulk OMM data with no standard wrapper

### Validation

Both schemas compile cleanly with flatc 24.3.25 (TypeScript and C++ targets verified).